### PR TITLE
packages/shared — Complete TypeScript types & Zod schemas for NAV reconciliation

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@nav-reconciliation/shared",
+  "version": "0.0.0",
+  "private": true,
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "zod": "^3.24.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.0",
+    "vitest": "^1.0.0"
+  }
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,0 +1,4 @@
+export * from './types/enums.js';
+export * from './types/registry.js';
+export * from './types/injector.js';
+export * from './types/nav.js';

--- a/packages/shared/src/types/__tests__/injector.test.ts
+++ b/packages/shared/src/types/__tests__/injector.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { RawPositionReadSchema, BalanceSnapshotSchema } from '../injector.js';
+import { Protocol } from '../enums.js';
+
+describe('RawPositionReadSchema', () => {
+  const validRead = {
+    protocol: Protocol.AAVE_V3,
+    contractAddress: '0xabc123def456abc123def456abc123def456abc1',
+    method: 'balanceOf',
+    rawValue: '5000000000000000000',
+    decimals: 18,
+    blockNumber: '19000000',
+  };
+
+  it('parses a valid raw position read', () => {
+    const result = RawPositionReadSchema.safeParse(validRead);
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects numeric rawValue (must be string)', () => {
+    const result = RawPositionReadSchema.safeParse({
+      ...validRead,
+      rawValue: 5000000000000000000,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects numeric blockNumber (must be string)', () => {
+    const result = RawPositionReadSchema.safeParse({
+      ...validRead,
+      blockNumber: 19000000,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects invalid protocol', () => {
+    const result = RawPositionReadSchema.safeParse({
+      ...validRead,
+      protocol: 'INVALID',
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('BalanceSnapshotSchema', () => {
+  const validSnapshot = {
+    address: '0xabc123def456abc123def456abc123def456abc1',
+    protocol: Protocol.GMX_V2,
+    rawValue: '1000000000',
+    decimals: 6,
+    blockNumber: '19000000',
+    timestamp: 1700000000,
+  };
+
+  it('parses a valid balance snapshot', () => {
+    const result = BalanceSnapshotSchema.safeParse(validSnapshot);
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects numeric rawValue (must be string)', () => {
+    const result = BalanceSnapshotSchema.safeParse({
+      ...validSnapshot,
+      rawValue: 1000000000,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects numeric blockNumber (must be string)', () => {
+    const result = BalanceSnapshotSchema.safeParse({
+      ...validSnapshot,
+      blockNumber: 19000000,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects invalid protocol', () => {
+    const result = BalanceSnapshotSchema.safeParse({
+      ...validSnapshot,
+      protocol: 'AAVE',
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/shared/src/types/__tests__/nav.test.ts
+++ b/packages/shared/src/types/__tests__/nav.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest';
+import { PositionBreakdownSchema, NavResultSchema } from '../nav.js';
+import { Protocol, Confidence } from '../enums.js';
+
+describe('PositionBreakdownSchema', () => {
+  const validBreakdown = {
+    protocol: Protocol.AAVE_V3,
+    valueUsdc: '1000000',
+    pct: '45.5',
+    blockNumber: '19000000',
+  };
+
+  it('parses a valid position breakdown', () => {
+    const result = PositionBreakdownSchema.safeParse(validBreakdown);
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects numeric valueUsdc (must be string)', () => {
+    const result = PositionBreakdownSchema.safeParse({
+      ...validBreakdown,
+      valueUsdc: 1000000,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects numeric pct (must be string)', () => {
+    const result = PositionBreakdownSchema.safeParse({
+      ...validBreakdown,
+      pct: 45.5,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects invalid protocol', () => {
+    const result = PositionBreakdownSchema.safeParse({
+      ...validBreakdown,
+      protocol: 'COMPOUND',
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('NavResultSchema', () => {
+  const validNav = {
+    recommendedNav: '10000000',
+    currentOnChainNav: '9990000',
+    delta: '10000',
+    deltaBps: '10',
+    breakdown: [
+      {
+        protocol: Protocol.AAVE_V3,
+        valueUsdc: '6000000',
+        pct: '60.0',
+        blockNumber: '19000000',
+      },
+      {
+        protocol: Protocol.IDLE,
+        valueUsdc: '4000000',
+        pct: '40.0',
+        blockNumber: '19000000',
+      },
+    ],
+    pendingDeposits: '100000',
+    pendingRedemptions: '50000',
+    pendingRedemptionShares: '48000',
+    confidence: Confidence.HIGH,
+    blockNumber: '19000000',
+    calculatedAt: '2024-01-01T00:00:00.000Z',
+  };
+
+  it('parses a valid nav result', () => {
+    const result = NavResultSchema.safeParse(validNav);
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects numeric recommendedNav (must be string)', () => {
+    const result = NavResultSchema.safeParse({
+      ...validNav,
+      recommendedNav: 10000000,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects numeric delta (must be string)', () => {
+    const result = NavResultSchema.safeParse({
+      ...validNav,
+      delta: 10000,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects invalid confidence', () => {
+    const result = NavResultSchema.safeParse({
+      ...validNav,
+      confidence: 'VERY_HIGH',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects numeric pendingDeposits (must be string)', () => {
+    const result = NavResultSchema.safeParse({
+      ...validNav,
+      pendingDeposits: 100000,
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/shared/src/types/enums.ts
+++ b/packages/shared/src/types/enums.ts
@@ -1,0 +1,11 @@
+export enum Protocol {
+  AAVE_V3 = 'AAVE_V3',
+  GMX_V2 = 'GMX_V2',
+  IDLE = 'IDLE',
+}
+
+export enum Confidence {
+  HIGH = 'HIGH',
+  MEDIUM = 'MEDIUM',
+  LOW = 'LOW',
+}

--- a/packages/shared/src/types/injector.ts
+++ b/packages/shared/src/types/injector.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod';
+import { Protocol } from './enums.js';
+
+export const RawPositionReadSchema = z.object({
+  protocol: z.nativeEnum(Protocol),
+  contractAddress: z.string(),
+  method: z.string(),
+  rawValue: z.string(),
+  decimals: z.number(),
+  blockNumber: z.string(),
+});
+
+export type RawPositionRead = z.infer<typeof RawPositionReadSchema>;
+
+export const BalanceSnapshotSchema = z.object({
+  address: z.string(),
+  protocol: z.nativeEnum(Protocol),
+  rawValue: z.string(),
+  decimals: z.number(),
+  blockNumber: z.string(),
+  timestamp: z.number(),
+});
+
+export type BalanceSnapshot = z.infer<typeof BalanceSnapshotSchema>;

--- a/packages/shared/src/types/nav.ts
+++ b/packages/shared/src/types/nav.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod';
+import { Confidence, Protocol } from './enums.js';
+
+export const PositionBreakdownSchema = z.object({
+  protocol: z.nativeEnum(Protocol),
+  valueUsdc: z.string(),
+  pct: z.string(),
+  blockNumber: z.string(),
+});
+
+export type PositionBreakdown = z.infer<typeof PositionBreakdownSchema>;
+
+export const NavResultSchema = z.object({
+  recommendedNav: z.string(),
+  currentOnChainNav: z.string(),
+  delta: z.string(),
+  deltaBps: z.string(),
+  breakdown: z.array(PositionBreakdownSchema),
+  pendingDeposits: z.string(),
+  pendingRedemptions: z.string(),
+  pendingRedemptionShares: z.string(),
+  confidence: z.nativeEnum(Confidence),
+  blockNumber: z.string(),
+  calculatedAt: z.string(),
+});
+
+export type NavResult = z.infer<typeof NavResultSchema>;

--- a/packages/shared/src/types/registry.ts
+++ b/packages/shared/src/types/registry.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod';
+import { Protocol } from './enums.js';
+
+export const ProtocolAllocationSchema = z.object({
+  protocol: z.nativeEnum(Protocol),
+  chainId: z.number(),
+  contractAddress: z.string(),
+});
+
+export type ProtocolAllocation = z.infer<typeof ProtocolAllocationSchema>;
+
+export const VaultConfigSchema = z.object({
+  address: z.string(),
+  chainId: z.number(),
+  underlyingToken: z.string(),
+  underlyingDecimals: z.number(),
+  standard: z.literal('ERC-7540'),
+  protocols: z.array(ProtocolAllocationSchema),
+});
+
+export type VaultConfig = z.infer<typeof VaultConfigSchema>;

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "paths": {}
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "strict": true,
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  }
+}


### PR DESCRIPTION
## What

The following files were modified to complete all TypeScript type definitions and Zod runtime validation schemas for the NAV reconciliation monorepo's shared package:

- `packages/shared/package.json` — Added `zod` as a dependency
- `packages/shared/tsconfig.json` — TypeScript config aligned with monorepo base
- `packages/shared/src/index.ts` — Re-exports all types and schemas from all four type files
- `packages/shared/src/types/enums.ts` — `Protocol` (`AAVE_V3`, `GMX_V2`, `IDLE`) and `Confidence` (`HIGH`, `MEDIUM`, `LOW`) as TypeScript string enums
- `packages/shared/src/types/registry.ts` — `VaultConfig` and `ProtocolAllocation` types + `VaultConfigSchema`, `ProtocolAllocationSchema`
- `packages/shared/src/types/injector.ts` — `RawPositionRead` and `BalanceSnapshot` types + `RawPositionReadSchema`, `BalanceSnapshotSchema`
- `packages/shared/src/types/nav.ts` — `PositionBreakdown` and `NavResult` types + `PositionBreakdownSchema`, `NavResultSchema`
- `packages/shared/src/types/__tests__/injector.test.ts` — Tests validating `RawPositionReadSchema` and `BalanceSnapshotSchema` parse/reject correctly
- `packages/shared/src/types/__tests__/nav.test.ts` — Tests validating `NavResultSchema` and `PositionBreakdownSchema` parse/reject correctly
- `tsconfig.base.json` — Monorepo base TypeScript config updated

## Acceptance criteria

- [x] All 8 types above are fully defined with every field named and typed — no `any`, no `unknown`, no empty `{}`
- [x] Every Zod schema co-located in the same file as its TypeScript type, exported as `[TypeName]Schema`
- [x] All financial value fields in Zod schemas use `z.string()` (not `z.number()` or `z.bigint()`)
- [x] `Protocol` and `Confidence` are TypeScript string enums (not `const` objects) with all values present
- [x] `packages/shared` exports all types and schemas from `src/index.ts`
- [x] `turbo run typecheck --filter=@nav-reconciliation/shared` passes with zero errors (`tsc --noEmit` passed; package name set to `@nav-reconciliation/shared`)
- [x] Existing tests in `packages/shared/src/types/__tests__/` are updated to validate Zod schemas parse correctly (including rejection of `number` for financial fields) — 17 tests passed, 0 failed

## Parent issue

Part of #13

Closes #14

---
Closes #14